### PR TITLE
chore: replace upstream with fork throughout

### DIFF
--- a/formatter/ascii.go
+++ b/formatter/ascii.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"sort"
 
-	diff "github.com/yudai/gojsondiff"
+	diff "github.com/Kong/gojsondiff"
 )
 
 func NewAsciiFormatter(left interface{}, config AsciiFormatterConfig) *AsciiFormatter {

--- a/formatter/ascii_test.go
+++ b/formatter/ascii_test.go
@@ -1,13 +1,13 @@
 package formatter_test
 
 import (
-	. "github.com/yudai/gojsondiff/formatter"
+	. "github.com/Kong/gojsondiff/formatter"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/yudai/gojsondiff/tests"
+	. "github.com/Kong/gojsondiff/tests"
 
-	diff "github.com/yudai/gojsondiff"
+	diff "github.com/Kong/gojsondiff"
 )
 
 var _ = Describe("Ascii", func() {

--- a/formatter/delta.go
+++ b/formatter/delta.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	diff "github.com/yudai/gojsondiff"
+	diff "github.com/Kong/gojsondiff"
 )
 
 const (

--- a/formatter/delta_test.go
+++ b/formatter/delta_test.go
@@ -1,13 +1,13 @@
 package formatter_test
 
 import (
-	. "github.com/yudai/gojsondiff/formatter"
+	. "github.com/Kong/gojsondiff/formatter"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/yudai/gojsondiff/tests"
+	. "github.com/Kong/gojsondiff/tests"
 
-	diff "github.com/yudai/gojsondiff"
+	diff "github.com/Kong/gojsondiff"
 )
 
 var _ = Describe("Delta", func() {

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/onsi/ginkgo v1.1.1-0.20150303023352-38caab951a9f
 	github.com/onsi/gomega v0.0.0-20150401040250-4dfabf7db2e4
 	github.com/urfave/cli v1.19.2-0.20170215051705-2526b57c56f3
-	github.com/yudai/gojsondiff v1.0.0
 	github.com/yudai/golcs v0.0.0-20150405163532-d1c525dea8ce
 	github.com/yudai/pp v2.0.2-0.20150410014804-be8315415630+incompatible
 )
@@ -17,6 +16,5 @@ require (
 	github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88 // indirect
 	github.com/mattn/go-colorable v0.0.6 // indirect
 	github.com/mattn/go-isatty v0.0.0-20160806122752-66b8e73f3f5c // indirect
-	github.com/sergi/go-diff v1.2.0 // indirect
 	golang.org/x/sys v0.0.0-20160717071931-a646d33e2ee3 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -20,16 +20,12 @@ github.com/onsi/gomega v0.0.0-20150401040250-4dfabf7db2e4 h1:vXLCFNIK5zI1YgKSvgc
 github.com/onsi/gomega v0.0.0-20150401040250-4dfabf7db2e4/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
-github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/urfave/cli v1.19.2-0.20170215051705-2526b57c56f3 h1:aLFlkys2/c3jUVHyHhPeQjC5TZ8TtxHZhq5b7qpm0QE=
 github.com/urfave/cli v1.19.2-0.20170215051705-2526b57c56f3/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
-github.com/yudai/gojsondiff v1.0.0 h1:27cbfqXLVEJ1o8I6v3y9lg8Ydm53EKqHXAOMxEGlCOA=
-github.com/yudai/gojsondiff v1.0.0/go.mod h1:AY32+k2cwILAkW1fbgxQ5mUmMiZFgLIV+FBNExI05xg=
 github.com/yudai/golcs v0.0.0-20150405163532-d1c525dea8ce h1:888GrqRxabUce7lj4OaoShPxodm3kXOMpSa85wdYzfY=
 github.com/yudai/golcs v0.0.0-20150405163532-d1c525dea8ce/go.mod h1:lgjkn3NuSvDfVJdfcVVdX+jpBxNmX4rDAzaS45IcYoM=
 github.com/yudai/pp v2.0.2-0.20150410014804-be8315415630+incompatible h1:TmF93o7P81230DTx1l2zw5rZbsDpOOQXoKVCa8+nXXI=

--- a/gojsondiff_test.go
+++ b/gojsondiff_test.go
@@ -1,11 +1,11 @@
 package gojsondiff_test
 
 import (
-	. "github.com/yudai/gojsondiff"
+	. "github.com/Kong/gojsondiff"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/yudai/gojsondiff/tests"
+	. "github.com/Kong/gojsondiff/tests"
 
 	"io/ioutil"
 )

--- a/jd/main.go
+++ b/jd/main.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/urfave/cli"
 
-	diff "github.com/yudai/gojsondiff"
-	"github.com/yudai/gojsondiff/formatter"
+	diff "github.com/Kong/gojsondiff"
+	"github.com/Kong/gojsondiff/formatter"
 )
 
 func main() {

--- a/jp/main.go
+++ b/jp/main.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/urfave/cli"
 
-	diff "github.com/yudai/gojsondiff"
+	diff "github.com/Kong/gojsondiff"
 )
 
 func main() {

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -1,11 +1,11 @@
 package gojsondiff_test
 
 import (
-	. "github.com/yudai/gojsondiff"
+	. "github.com/Kong/gojsondiff"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/yudai/gojsondiff/tests"
+	. "github.com/Kong/gojsondiff/tests"
 
 	"encoding/json"
 	"fmt"


### PR DESCRIPTION
The original fork left internal references to upstream in place. This changes all references to this fork.